### PR TITLE
Remove pyqt

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-ndscope-green.svg)](https://anaconda.org/conda-forge/ndscope) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/ndscope.svg)](https://anaconda.org/conda-forge/ndscope) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/ndscope.svg)](https://anaconda.org/conda-forge/ndscope) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/ndscope.svg)](https://anaconda.org/conda-forge/ndscope) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-ndscope--base-green.svg)](https://anaconda.org/conda-forge/ndscope-base) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/ndscope-base.svg)](https://anaconda.org/conda-forge/ndscope-base) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/ndscope-base.svg)](https://anaconda.org/conda-forge/ndscope-base) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/ndscope-base.svg)](https://anaconda.org/conda-forge/ndscope-base) |
 
 Installing ndscope
 ==================
@@ -52,16 +53,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `ndscope` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `ndscope, ndscope-base` can be installed with `conda`:
 
 ```
-conda install ndscope
+conda install ndscope ndscope-base
 ```
 
 or with `mamba`:
 
 ```
-mamba install ndscope
+mamba install ndscope ndscope-base
 ```
 
 It is possible to list all of the versions of `ndscope` available on your platform with `conda`:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Home: https://git.ligo.org/cds/ndscope
 
 Package license: GPL-3.0-or-later
 
-Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/ndscope-feedstock/blob/master/LICENSE.txt)
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/ndscope-feedstock/blob/main/LICENSE.txt)
 
 Summary: Next-generation NDS oscilloscope
 
@@ -28,8 +28,8 @@ Current build status
 
 <table><tr><td>All platforms:</td>
     <td>
-      <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8640&branchName=master">
-        <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ndscope-feedstock?branchName=master">
+      <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8640&branchName=main">
+        <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ndscope-feedstock?branchName=main">
       </a>
     </td>
   </tr>
@@ -52,16 +52,41 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `ndscope` can be installed with:
+Once the `conda-forge` channel has been enabled, `ndscope` can be installed with `conda`:
 
 ```
 conda install ndscope
 ```
 
-It is possible to list all of the versions of `ndscope` available on your platform with:
+or with `mamba`:
+
+```
+mamba install ndscope
+```
+
+It is possible to list all of the versions of `ndscope` available on your platform with `conda`:
 
 ```
 conda search ndscope --channel conda-forge
+```
+
+or with `mamba`:
+
+```
+mamba search ndscope --channel conda-forge
+```
+
+Alternatively, `mamba repoquery` may provide more information:
+
+```
+# Search all versions available on your platform:
+mamba repoquery search ndscope --channel conda-forge
+
+# List packages depending on `ndscope`:
+mamba repoquery whoneeds ndscope --channel conda-forge
+
+# List dependencies of `ndscope`:
+mamba repoquery depends ndscope --channel conda-forge
 ```
 
 
@@ -79,10 +104,12 @@ for each of the installable packages. Such a repository is known as a *feedstock
 A feedstock is made up of a conda recipe (the instructions on what and how to build
 the package) and the necessary configurations for automatic building using freely
 available continuous integration services. Thanks to the awesome service provided by
-[CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
-and [TravisCI](https://travis-ci.com/) it is possible to build and upload installable
-packages to the [conda-forge](https://anaconda.org/conda-forge)
-[Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
+[Azure](https://azure.microsoft.com/en-us/services/devops/), [GitHub](https://github.com/),
+[CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/),
+[Drone](https://cloud.drone.io/welcome), and [TravisCI](https://travis-ci.com/)
+it is possible to build and upload installable packages to the
+[conda-forge](https://anaconda.org/conda-forge) [Anaconda-Cloud](https://anaconda.org/)
+channel for Linux, Windows and OSX respectively.
 
 To manage the continuous integration and simplify feedstock maintenance
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,6 +59,7 @@ outputs:
     test:
       requires:
         - pytest
+        - setuptools
       commands:
         # run test suite
         - python -m pytest --pyargs ndscope

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -67,6 +67,30 @@ outputs:
         - ndscope --help
         - ndschans --help
 
+    about:
+      home: https://git.ligo.org/cds/ndscope
+      dev_url: https://git.ligo.org/cds/ndscope
+      license: GPL-3.0-or-later
+      license_family: GPL
+      license_file: COPYING
+      summary: Next-generation NDS oscilloscope
+      description: |
+        View time series data of channels from LIGO network data servers
+        (NDS) with an intuitive GUI interface.  Features include:
+
+        * online and offline data viewing
+        * intuitive mouse gestures for pan and zoom
+        * auto-retrieval of new data as the time range expands
+        * auto-switching from raw data to second/minute trends depending
+          on time scale
+        * supports both NDS1 and NDS2 protocols, for viewing both in
+          LIGO/Kagra control rooms as well as anywhere else in the world
+
+        The `ndscope` conda-forge package is a metapackage that bundles a
+        requirement on `pyqt` to ensure a working runtime Qt implementation.
+        See `ndscope-base` for a package that does not include a requirement
+        on `pyqt`.
+
 about:
   home: https://git.ligo.org/cds/ndscope
   dev_url: https://git.ligo.org/cds/ndscope
@@ -77,6 +101,7 @@ about:
   description: |
     View time series data of channels from LIGO network data servers
     (NDS) with an intuitive GUI interface.  Features include:
+
     * online and offline data viewing
     * intuitive mouse gestures for pan and zoom
     * auto-retrieval of new data as the time range expands
@@ -84,6 +109,11 @@ about:
       on time scale
     * supports both NDS1 and NDS2 protocols, for viewing both in
       LIGO/Kagra control rooms as well as anywhere else in the world
+
+    The `ndscope-base` package has a minimal requirement set, and does
+    not bundle a requirement on `pyqt` or any underlying Python Qt
+    implementation, so you may have to manually install one.
+    See the `ndscope` metapackage for a user-friendly bundled version.
 
 extra:
   feedstock-name: ndscope

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "0.15.1" %}
 
 package:
-  name: ndscope
+  name: ndscope-base
   version: {{ version }}
 
 source:
@@ -40,15 +40,31 @@ requirements:
 test:
   requires:
     - pip
-    - pyqt
-    - pytest
-  imports:
-    - ndscope
   commands:
-    - pip check
-    - python -m pytest --pyargs ndscope
-    - ndscope --help
-    - ndschans --help
+    # check requirements
+    - python -m pip check
+
+outputs:
+  - name: ndscope-base
+  - name: ndscope
+    build:
+      noarch: python
+    requirements:
+      host:
+        - python >=3.7
+      run:
+        - python >=3.7
+        - {{ pin_subpackage('ndscope-base', max_pin='x.x.x.x') }}
+        - pyqt
+    test:
+      requires:
+        - pytest
+      commands:
+        # run test suite
+        - python -m pytest --pyargs ndscope
+        # check entry points
+        - ndscope --help
+        - ndschans --help
 
 about:
   home: https://git.ligo.org/cds/ndscope
@@ -69,6 +85,7 @@ about:
       LIGO/Kagra control rooms as well as anywhere else in the world
 
 extra:
+  feedstock-name: ndscope
   recipe-maintainers:
     - duncanmmacleod
     - jrollins

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,6 +40,7 @@ requirements:
 test:
   requires:
     - pip
+    - pyqt
     - pytest
   imports:
     - ndscope

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,9 +13,9 @@ build:
   entry_points:
     - ndscope = ndscope.__main__:main
     - ndschans = ndscope.channel_select:main
-  number: 0
+  number: 1
   noarch: python
-  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+  script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
@@ -34,7 +34,6 @@ requirements:
     - python-dateutil
     - python-nds2-client
     - pyyaml
-    - pyqt >=5
     - qtpy
     - setproctitle
 


### PR DESCRIPTION
This MR removes the unused requirement on `pyqt`, imports of that module were removed in [0.14.0](https://git.ligo.org/cds/ndscope/-/commit/86de17cc83d7a58a9317a04cb1496441a82a61ac).

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
