### PR TITLE
Fix recipe to work with latest rattler-build release

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ stages:
   jobs:
     - job: Skip
       pool:
-        vmImage: 'ubuntu-22.04'
+        vmImage: 'ubuntu-latest'
       variables:
         DECODE_PERCENTS: 'false'
         RET: 'true'

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -17,7 +17,7 @@ build:
     entry_points:
       - ndscope = ndscope.__main__:main
       - ndschans = ndscope.channel_select:main
-  number: 0
+  number: 1
   noarch: python
   script: ${{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
 
@@ -51,7 +51,7 @@ tests:
         - pip
         - pytest
         - pytest-console-scripts
-        - python ${{ python_min }}
+        - python ${{ python_min }}.*
           # imports:
           #   - ndscope
     script:


### PR DESCRIPTION
Add explicit `.*` glob suffix to bare python version specifiers like `python ${{ python_min }}` to make them valid match specs.